### PR TITLE
Editor style updates

### DIFF
--- a/assets/styles/override-editor.scss
+++ b/assets/styles/override-editor.scss
@@ -34,11 +34,13 @@ $editor: (
 
 // Add new block button.
 .block-list-appender {
-  position: absolute;
-  right: 0;
-  bottom: -11px;
-  border-radius: 10px 0 0;
-  z-index: 1;
+  position: fixed;
+  right: 50%;
+  transform: translateX(-50%);
+  bottom: 0;
+  width: 100px;
+  z-index: 100;
+  border-radius: 10px 10px 0 0;
   background-color: map-get-strict($editor, appender-bg-color);
 
   button {
@@ -60,8 +62,11 @@ $editor: (
 
     // Block appender. Used with inner blocks.
     .block-list-appender {
+      position: absolute;
       right: 10px;
       bottom: 5px;
+      transform: none;
+      width: auto;
       border-radius: 50%;
       background-color: darken(map-get-strict($editor, appender-bg-color), 15%);
     }

--- a/blocks/manifest.json
+++ b/blocks/manifest.json
@@ -1,4 +1,4 @@
 {
   "namespace": "eightshift-boilerplate",
-  "background": "#900000"
+  "background": "#880000"
 }


### PR DESCRIPTION
Global block insert button is now fixed to the bottom of the page and is a bit more visible.
Block insert button in sections kept its previous styling.

Background color of Eightshift blocks in block picker is set to #880000 (because Eightshift)